### PR TITLE
Add deploy script, fix deploy bug

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,35 +78,10 @@ Running on AWS
 
 You can use in-tree awsbox scripts to deploy kpiggybank on Amazon's cloud infrastructure.
 
-Clone kpiggybank:
+This process is now just like the process of deploying browserid on AWS, see:
+https://github.com/mozilla/browserid/blob/dev/docs/AWS_DEPLOYMENT.md
 
-    $ git clone https://github.com/mozilla/kpiggybank
-    
-Install node modules:
-    
-    $ npm install
-
-You'll need an AWS account "signed up" for EC2. To set up AWS credentials for the scripts to access, you might put something like this
-in your `.bashrc`:
-
-    # This is your Access Key ID from your AWS Security Credentials
-    export AWS_ID=<your id>
-    # This is your Secret Access Key from your AWS Security Credentials
-    export AWS_SECRET=<your secret>
-
-Make sure you have an ssh key in ~/.ssh/id_rsa.pub
-
-Now you can run the awsbox script, which will fire up an AWS instance and install couchdb. Choose a name for your VM:
-
-    $ node_modules/.bin/awsbox create -n myvm
-
-Once it's ready, push the kpiggybank code to the server (this will trigger awsbox to startup kpiggybank):
-
-    $ git push myvm HEAD:master
-
-Now `http://<aws-ip>` should point to your new kpiggybank.
-
-For more information about awsbox: https://github.com/mozilla/awsbox
+The one modification is that kpiggybank's deploy script ignores mail setup.
 
 JS API
 ------

--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ Requirements
 Installation
 ------------
 
-- git clone: `https://github.com/jedp/kpiggybank`
+- git clone: `https://github.com/mozilla/kpiggybank`
 - `npm install`
 
 Testing
@@ -73,6 +73,40 @@ ensure that the db exists, creating it if it doesn't.
 Please note that the database named `bid_kpi_test` is **deleted** as part of the 
 test suite.
 
+Running on AWS
+--------------
+
+You can use in-tree awsbox scripts to deploy kpiggybank on Amazon's cloud infrastructure.
+
+Clone kpiggybank:
+
+    $ git clone https://github.com/mozilla/kpiggybank
+    
+Install node modules:
+    
+    $ npm install
+
+You'll need an AWS account "signed up" for EC2. To set up AWS credentials for the scripts to access, you might put something like this
+in your `.bashrc`:
+
+    # This is your Access Key ID from your AWS Security Credentials
+    export AWS_ID=<your id>
+    # This is your Secret Access Key from your AWS Security Credentials
+    export AWS_SECRET=<your secret>
+
+Make sure you have an ssh key in ~/.ssh/id_rsa.pub
+
+Now you can run the awsbox script, which will fire up an AWS instance and install couchdb. Choose a name for your VM:
+
+    $ node_modules/.bin/awsbox create -n myvm
+
+Once it's ready, push the kpiggybank code to the server (this will trigger awsbox to startup kpiggybank):
+
+    $ git push myvm HEAD:master
+
+Now `http://<aws-ip>` should point to your new kpiggybank.
+
+For more information about awsbox: https://github.com/mozilla/awsbox
 
 JS API
 ------

--- a/scripts/aws_post_create.sh
+++ b/scripts/aws_post_create.sh
@@ -14,6 +14,3 @@ curl -X PUT $HOST/_config/admins/admin -d '"admin"'
 # now that an admin user exists, change the host
 HOST="http://admin:admin@localhost:5984"
 curl -X PUT $HOST/_config/admins/kpiggybank -d '"kpiggybank"'
-
-# create the kpi db
-curl -X PUT $HOST/bid_kpi

--- a/scripts/deploy.js
+++ b/scripts/deploy.js
@@ -1,0 +1,79 @@
+#!/usr/bin/env node
+
+var path = require('path'),
+child_process = require('child_process');
+
+/*
+ * Modified from browserid's deploy.js
+ *
+ * A thin wrapper around awsbox that expects certain env
+ * vars and invokes awsbox for ya to deploy a VM. 
+ */
+ if (!process.env['AWS_ID'] || ! process.env['AWS_SECRET']) {
+   console.log("You haven't defined AWS_ID and AWS_SECRET in the environment");
+   console.log("Get these values from the amazon web console and try again.");
+   process.exit(1);
+ }
+
+ if (!process.env['ZERIGO_DNS_KEY'] && process.env['PERSONA_DEPLOY_DNS_KEY']) { 
+   process.env['ZERIGO_DNS_KEY'] = process.env['PERSONA_DEPLOY_DNS_KEY'];
+ }
+
+ var cmd = path.join(__dirname, '..', 'node_modules', '.bin', 'awsbox');
+ cmd = path.relative(process.env['PWD'], cmd);
+
+ if (process.argv.length > 1 &&
+     process.argv[2] === 'create' || 
+     process.argv[2] === 'deploy')
+ {
+   var options = {};
+
+   if (process.argv.length > 3) options.n = process.argv[3];
+
+   if (process.env['PERSONA_SSL_PRIV'] || process.env['PERSONA_SSL_PUB']) {
+     options.p = process.env['PERSONA_SSL_PUB'];
+     options.s = process.env['PERSONA_SSL_PRIV'];
+   }
+
+   if (process.env['ZERIGO_DNS_KEY']) {
+     options.d = true;
+
+     // when we have a DNS key, we can set a hostname!
+     var scheme = (options.p ? 'https' : 'http') + '://';
+
+     if (process.env['PERSONA_DEPLOYMENT_HOSTNAME']) {
+       options.u = scheme + process.env['PERSONA_DEPLOYMENT_HOSTNAME'];
+     } else if (options.n) {
+       options.u = scheme + options.n + ".personatest.org";
+     }
+
+   } else {
+     console.log('WARNING: No DNS key defined in the environment!  ' +
+                 'I cannot set up DNS for you.  We\'ll do this by IP.');
+   }
+
+   // pass through/override with user provided vars
+   for (var i = 3; i < process.argv.length; i++) {
+     var k = process.argv[i];
+     if (i + 1 < process.argv.length && k.length === 2 && k[0] === '-') {
+       options[k[1]] = process.argv[++i];
+     }
+   }
+
+   cmd += " create --ssl=force";
+
+   Object.keys(options).forEach(function(opt) {
+     cmd += " -" + opt;
+     cmd += typeof options[opt] === 'string' ? " " + options[opt] : "";
+   });
+ } else {
+   cmd += " " + process.argv.slice(2).join(' ');
+ }
+
+ console.log("awsbox cmd: " + cmd);
+ var cp = child_process.exec(cmd, function(err) {
+   if (err) process.exit(err.code);
+   else process.exit(0);
+ });
+ cp.stdout.pipe(process.stdout);
+ cp.stderr.pipe(process.stderr);


### PR DESCRIPTION
Fixes a bug in the post create script (creating the bid_kpi db in the script circumvented the creation of the views). Adds a deploy script so that we can set up DNS and SSL easily, just like browserid. Updates the README for AWS.
