### PR TITLE
Fix #10, JSON.parse failure should be 400 Bad Request, not 500 Internal Server Error 

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -128,7 +128,7 @@ app.post('/wsapi/interaction_data', function(req, res) {
     });
   } catch (e) {
     logger.error(e);
-    res.send('oh dear', 500);
+    res.send('JSON syntax error', 400);
   }
 });
 

--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
 
     "devDependencies": {
         "vows": "0.6.2",
-        "awsbox": "*"
+        "awsbox": "0.4.2"
     },
 
     "scripts": {


### PR DESCRIPTION
Fix #10, JSON.parse failure should be 400 Bad Request, not 500 Internal Server Error 
Pin awsbox version to 0.4.2 (has security group command line option)
