### PR TITLE
Turn off cradle caching and update libs

### DIFF
--- a/lib/backends/couchdb.js
+++ b/lib/backends/couchdb.js
@@ -5,6 +5,7 @@ var Backend = function Backend(message, config, callback) {
 
   this.message = message;
   this.conn = new (cradle.Connection)(config.db_host, config.db_port, {
+    cache: false,
     auth: {
       username: config.db_user,
       password: config.db_pass

--- a/package.json
+++ b/package.json
@@ -8,12 +8,12 @@
 
     "dependencies": {
       "backbone": "0.9.2",
-      "cradle": "0.6.3",
+      "cradle": "0.6.5",
       "express": "2.5.9",
       "jade": ">= 0.25.0",
       "JSV": "4.0.1",
       "request": "2.9.202",
-      "socket.io": "0.9.6",
+      "socket.io": "0.9.14",
       "underscore": "1.3.3",
       "urlparse": "0.0.1",
       "winston": "0.5.11"
@@ -30,6 +30,6 @@
     },
 
     "engines": {
-        "node": ">= 0.6.17"
+        "node": ">= 0.8.11"
     }
 }


### PR DESCRIPTION
We don't need caching in cradle, this seems to fix our memory leak #15, also probably addresses #23.
