### PR TITLE
added /last wsapi method

### DIFF
--- a/lib/server.js
+++ b/lib/server.js
@@ -187,6 +187,17 @@ app.get('/wsapi/interaction_data/count', function(req, res) {
   });
 });
 
+app.get('/wsapi/interaction_data/last', function(req, res) {
+  db.fetchRange({limit:1, descending:true}, function(err, results) {
+    if (err) {
+      res.writeHead(500);
+      return res.end({'error':"Computer says no."});
+    }
+    res.writeHead(200);
+    return res.end(JSON.stringify(results[0]));
+  });
+});
+
 app.get('/wsapi/interaction_data/stream', function(req, res) {
   res.writeHead(200);
   db.on('change', function(change) {


### PR DESCRIPTION
@shane-tomlinson:

Implements /wsapi/interaction_data/last using limit:1 and descending:true, instead of grabbing all of the results and looking at the last one (https://github.com/mozilla/kpiggybank/pull/18)

assumes uuids are not generated randomly, as set in default.ini or local.ini:
[uuids]
algorithm = sequential
